### PR TITLE
Optimise backfill

### DIFF
--- a/src/main/kotlin/org/radarbase/gateway/Config.kt
+++ b/src/main/kotlin/org/radarbase/gateway/Config.kt
@@ -105,9 +105,9 @@ data class BackfillConfig(
     val userMetricsEnabled: Boolean = true,
     val moveIQEnabled: Boolean = true,
     val respirationEnabled: Boolean = true,
-    val bloodPressureEnabled: Boolean = true,
-    val healthSnapshotEnabled: Boolean = true,
-    val heartRateVariabilityEnabled: Boolean = true,
+    val bloodPressureEnabled: Boolean = false,
+    val healthSnapshotEnabled: Boolean = false,
+    val heartRateVariabilityEnabled: Boolean = false,
 )
 
 data class RedisConfig(

--- a/src/main/kotlin/org/radarbase/gateway/Config.kt
+++ b/src/main/kotlin/org/radarbase/gateway/Config.kt
@@ -94,6 +94,20 @@ data class BackfillConfig(
     val userBackfill: List<UserBackfillConfig> = emptyList(),
     val requestsPerUserPerIteration: Int = 40,
     val iterationIntervalMinutes: Long = 5,
+    val activitiesEnabled: Boolean = true,
+    val activityDetailsEnabled: Boolean = true,
+    val bodyCompositionsEnabled: Boolean = true,
+    val dailiesEnabled: Boolean = true,
+    val epochSummariesEnabled: Boolean = true,
+    val pulseOXEnabled: Boolean = true,
+    val sleepsEnabled: Boolean = true,
+    val stressEnabled: Boolean = true,
+    val userMetricsEnabled: Boolean = true,
+    val moveIQEnabled: Boolean = true,
+    val respirationEnabled: Boolean = true,
+    val bloodPressureEnabled: Boolean = true,
+    val healthSnapshotEnabled: Boolean = true,
+    val heartRateVariabilityEnabled: Boolean = true,
 )
 
 data class RedisConfig(

--- a/src/main/kotlin/org/radarbase/push/integration/garmin/backfill/GarminRequestGenerator.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/garmin/backfill/GarminRequestGenerator.kt
@@ -23,64 +23,93 @@ class GarminRequestGenerator(
     private val defaultQueryRange: Duration = Duration.ofDays(15),
 ) : RequestGenerator {
 
-    private val routes: List<Route> = listOf(
-        GarminActivitiesRoute(
-            config.pushIntegration.garmin.consumerKey,
-            userRepository
-        ),
-        GarminDailiesRoute(
-            config.pushIntegration.garmin.consumerKey,
-            userRepository
-        ),
-        GarminActivityDetailsRoute(
-            config.pushIntegration.garmin.consumerKey,
-            userRepository
-        ),
-        GarminBodyCompsRoute(
-            config.pushIntegration.garmin.consumerKey,
-            userRepository
-        ),
-        GarminEpochsRoute(
-            config.pushIntegration.garmin.consumerKey,
-            userRepository
-        ),
-        GarminMoveIQRoute(
-            config.pushIntegration.garmin.consumerKey,
-            userRepository
-        ),
-        GarminPulseOxRoute(
-            config.pushIntegration.garmin.consumerKey,
-            userRepository
-        ),
-        GarminRespirationRoute(
-            config.pushIntegration.garmin.consumerKey,
-            userRepository
-        ),
-        GarminSleepsRoute(
-            config.pushIntegration.garmin.consumerKey,
-            userRepository
-        ),
-        GarminStressDetailsRoute(
-            config.pushIntegration.garmin.consumerKey,
-            userRepository
-        ),
-        GarminUserMetricsRoute(
-            config.pushIntegration.garmin.consumerKey,
-            userRepository
-        ),
-        GarminHealthSnapshotRoute(
-            config.pushIntegration.garmin.consumerKey,
-            userRepository
-        ),
-        GarminHrvRoute(
-            config.pushIntegration.garmin.consumerKey,
-            userRepository
-        ),
-        GarminBloodPressureRoute(
-            config.pushIntegration.garmin.consumerKey,
-            userRepository
-        ),
-    )
+    private val routes: List<Route> =
+        mutableListOf<Route>().apply {
+            if (config.pushIntegration.garmin.backfill.activitiesEnabled) {
+                add(GarminActivitiesRoute(
+                    config.pushIntegration.garmin.consumerKey,
+                    userRepository
+                ))
+            }
+            if (config.pushIntegration.garmin.backfill.dailiesEnabled) {
+                add(GarminDailiesRoute(
+                    config.pushIntegration.garmin.consumerKey,
+                    userRepository
+                ))
+            }
+            if (config.pushIntegration.garmin.backfill.activityDetailsEnabled) {
+                add(GarminActivityDetailsRoute(
+                    config.pushIntegration.garmin.consumerKey,
+                    userRepository
+                ))
+            }
+            if (config.pushIntegration.garmin.backfill.bodyCompositionsEnabled) {
+                add(GarminBodyCompsRoute(
+                    config.pushIntegration.garmin.consumerKey,
+                    userRepository
+                ))
+            }
+            if (config.pushIntegration.garmin.backfill.epochSummariesEnabled) {
+                add(GarminEpochsRoute(
+                    config.pushIntegration.garmin.consumerKey,
+                    userRepository
+                ))
+            }
+            if (config.pushIntegration.garmin.backfill.moveIQEnabled) {
+                add(GarminMoveIQRoute(
+                    config.pushIntegration.garmin.consumerKey,
+                    userRepository
+                ))
+            }
+            if (config.pushIntegration.garmin.backfill.pulseOXEnabled) {
+                add(GarminPulseOxRoute(
+                    config.pushIntegration.garmin.consumerKey,
+                    userRepository
+                ))
+            }
+            if (config.pushIntegration.garmin.backfill.respirationEnabled) {
+                add(GarminRespirationRoute(
+                    config.pushIntegration.garmin.consumerKey,
+                    userRepository
+                ))
+            }
+            if (config.pushIntegration.garmin.backfill.sleepsEnabled) {
+                add(GarminSleepsRoute(
+                    config.pushIntegration.garmin.consumerKey,
+                    userRepository
+                ))
+            }
+            if (config.pushIntegration.garmin.backfill.stressEnabled) {
+                add(GarminStressDetailsRoute(
+                    config.pushIntegration.garmin.consumerKey,
+                    userRepository
+                ))
+            }
+            if (config.pushIntegration.garmin.backfill.userMetricsEnabled) {
+                add(GarminUserMetricsRoute(
+                    config.pushIntegration.garmin.consumerKey,
+                    userRepository
+                ))
+            }
+            if (config.pushIntegration.garmin.backfill.healthSnapshotEnabled) {
+                add(GarminHealthSnapshotRoute(
+                    config.pushIntegration.garmin.consumerKey,
+                    userRepository
+                ))
+            }
+            if (config.pushIntegration.garmin.backfill.heartRateVariabilityEnabled) {
+                add(GarminHrvRoute(
+                    config.pushIntegration.garmin.consumerKey,
+                    userRepository
+                ))
+            }
+            if (config.pushIntegration.garmin.backfill.bloodPressureEnabled) {
+                add(GarminBloodPressureRoute(
+                    config.pushIntegration.garmin.consumerKey,
+                    userRepository
+                ))
+            }
+        }.toList()
 
     private val userNextRequest: MutableMap<String, Instant> = mutableMapOf()
 


### PR DESCRIPTION
- Handle the case when route is not enabled in garmin dev portal explicitly
- Remove backfill for blood pressures, hrv and health snapshot by default as these are new and not present in all devices.
- Make all the backfill streams configurable, so can be enabled/disabled at runtime