### PR TITLE
Add audience interceptor to OkHttpClient for Hydra

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,6 +148,8 @@ jobs:
 
             # Gradle check
             - name: Integration test
+              env:
+                KAFKA_CONFLUENT_VERSION: 6.1.0
               run: |
                 echo "RADAR_PUSH_ENDPOINT_TAG=${{ steps.docker_meta.outputs.version }}" >> src/integrationTest/docker/.env
                 ./gradlew composeUp -PdockerComposeBuild=false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,6 +139,13 @@ jobs:
             - name: Setup Gradle
               uses: gradle/gradle-build-action@v2
 
+            # Install Docker Compose
+            - name: Install Docker Compose
+              run: |
+                sudo curl -L "https://github.com/docker/compose/releases/download/v2.24.5/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+                sudo chmod +x /usr/local/bin/docker-compose
+                docker-compose --version
+
             # Gradle check
             - name: Integration test
               run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -176,7 +176,7 @@ allprojects {
 }
 
 fun isNonStable(version: String): Boolean {
-    val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.toUpperCase().contains(it) }
+    val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.uppercase().contains(it) }
     val regex = "^[0-9,.v-]+(-r)?$".toRegex()
     val isStable = stableKeyword || regex.matches(version)
     return isStable.not()

--- a/src/integrationTest/docker/etc/gateway.yml
+++ b/src/integrationTest/docker/etc/gateway.yml
@@ -6,6 +6,3 @@ kafka:
         bootstrap.servers: kafka-1:9092
     serialization:
         schema.registry.url: http://schema-registry-1:8081
-
-auth:
-    managementPortalUrl: http://managementportal-app:8080


### PR DESCRIPTION
- Add audience param interceptor to OkHttpClient for Hydra (needed to be explicitly set)
- Updated docker compose task to use `v2` (`docker compose` instead of `docker-compose`)