### PR TITLE
Removing manual installation of docker compose in github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,13 +139,6 @@ jobs:
             - name: Setup Gradle
               uses: gradle/gradle-build-action@v2
 
-            # Install Docker Compose
-            - name: Install Docker Compose
-              run: |
-                sudo curl -L "https://github.com/docker/compose/releases/download/v2.24.5/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-                sudo chmod +x /usr/local/bin/docker-compose
-                docker-compose --version
-
             # Gradle check
             - name: Integration test
               env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("idea")
     id("application")
     kotlin("jvm")
-    id("com.avast.gradle.docker-compose") version "0.14.3"
+    id("com.avast.gradle.docker-compose") version "0.17.2"
     id("com.github.ben-manes.versions") version "0.39.0"
 }
 
@@ -142,8 +142,9 @@ dockerCompose {
     val dockerComposeStopContainers: String? by project
     stopContainers = dockerComposeStopContainers?.toBooleanLenient() ?: true
     waitForTcpPortsTimeout = Duration.ofMinutes(3)
-    environment["SERVICES_HOST"] = "localhost"
+    environment.put("SERVICES_HOST", "localhost")
     captureContainersOutputToFiles = project.file("build/container-logs")
+    useDockerComposeV2.set(true)
     isRequiredBy(integrationTest)
 }
 


### PR DESCRIPTION
From the docker compose plugin [documentation](**url**)

> Starting from plugin version 0.17.0, `useDockerComposeV2` property defaults to true, so the new docker compose (instead of deprecated docker-compose is used).

Thus removing the manual installation of docker compose in workflows