### PR TITLE
Limit the scope of the audience interceptor

### DIFF
--- a/src/main/kotlin/org/radarbase/gateway/inject/RadarResourceEnhancer.kt
+++ b/src/main/kotlin/org/radarbase/gateway/inject/RadarResourceEnhancer.kt
@@ -5,12 +5,10 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.jsonMapper
+import com.fasterxml.jackson.module.kotlin.kotlinModule
 import jakarta.ws.rs.ext.ContextResolver
-import okhttp3.FormBody
-import okhttp3.Interceptor
 import okhttp3.OkHttpClient
-import okhttp3.Request
 import org.glassfish.jersey.internal.inject.AbstractBinder
 import org.glassfish.jersey.server.ResourceConfig
 import org.radarbase.jersey.auth.filter.AuthenticationFilter
@@ -18,31 +16,17 @@ import org.radarbase.jersey.auth.filter.AuthorizationFeature
 import org.radarbase.jersey.enhancer.JerseyResourceEnhancer
 import java.util.concurrent.TimeUnit
 
-class RadarResourceEnhancer: JerseyResourceEnhancer {
+class RadarResourceEnhancer : JerseyResourceEnhancer {
 
-    var mapper: ObjectMapper = ObjectMapper()
-        .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-        .registerModule(JavaTimeModule())
-        .registerModule(KotlinModule())
-        .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-
-    val audienceInterceptor = Interceptor { chain ->
-        var req = chain.request()
-        if (req.method.equals("POST", ignoreCase = true) && req.body is FormBody) {
-            val oldBody = req.body as FormBody
-            val newBodyBuilder = FormBody.Builder()
-            for (i in 0 until oldBody.size) {
-                newBodyBuilder.addEncoded(oldBody.encodedName(i), oldBody.encodedValue(i))
-            }
-            newBodyBuilder.add("audience", "res_restAuthorizer")
-            req = req.newBuilder().post(newBodyBuilder.build()).build()
-        }
-        chain.proceed(req)
+    var mapper: ObjectMapper = jsonMapper {
+        addModule(JavaTimeModule())
+        addModule(kotlinModule())
+        serializationInclusion(JsonInclude.Include.NON_NULL)
+        configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+        configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     }
 
     var client: OkHttpClient = OkHttpClient().newBuilder()
-        .addInterceptor(audienceInterceptor)
         .connectTimeout(10, TimeUnit.SECONDS)
         .writeTimeout(10, TimeUnit.SECONDS)
         .readTimeout(30, TimeUnit.SECONDS)
@@ -50,7 +34,8 @@ class RadarResourceEnhancer: JerseyResourceEnhancer {
 
     override val classes = arrayOf(
         AuthenticationFilter::class.java,
-        AuthorizationFeature::class.java)
+        AuthorizationFeature::class.java
+    )
 
     override fun ResourceConfig.enhance() {
         register(ContextResolver { mapper })

--- a/src/main/kotlin/org/radarbase/push/integration/garmin/user/GarminServiceUserRepository.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/garmin/user/GarminServiceUserRepository.kt
@@ -60,11 +60,15 @@ class GarminServiceUserRepository(
         if (clientId.isEmpty())
             throw ConfigException("Client ID for user repository is not set.")
 
+        val tokenClient = client.newBuilder()
+            .addInterceptor(AUDIENCE_INTERCEPTOR)
+            .build()
+
         repositoryClient = OAuth2Client.Builder()
             .credentials(clientId, clientSecret)
             .endpoint(tokenUrl)
             .scopes("SUBJECT.READ", "MEASUREMENT.READ", "SUBJECT.UPDATE", "MEASUREMENT.CREATE")
-            .httpClient(client)
+            .httpClient(tokenClient)
             .build()
     }
 
@@ -196,5 +200,28 @@ class GarminServiceUserRepository(
         private val MIN_INSTANT: Instant = Instant.EPOCH
 
         private val logger = LoggerFactory.getLogger(GarminServiceUserRepository::class.java)
+
+        private const val RSA_AUDIENCE = "res_restAuthorizer"
+
+        private val AUDIENCE_INTERCEPTOR = Interceptor { chain ->
+            val request = chain.request()
+            val formBody = request.body as? FormBody
+            if (formBody == null || request.method != "POST") {
+                return@Interceptor chain.proceed(request)
+            }
+
+            val rewrittenBody = FormBody.Builder().apply {
+                repeat(formBody.size) { i ->
+                    addEncoded(formBody.encodedName(i), formBody.encodedValue(i))
+                }
+                add("audience", RSA_AUDIENCE)
+            }.build()
+
+            chain.proceed(
+                request.newBuilder()
+                    .post(rewrittenBody)
+                    .build(),
+            )
+        }
     }
 }


### PR DESCRIPTION
Right now the audience interceptor sits on the globally shared http client in `RadarResourceEnhancer`, which is used by both GarminServiceUserRepository and BackfillService. So every call in the app runs through its `POST + FormBody` check.                                                                             
There's only one request that actually matches today and it works fine, but as we start adding the Fitbit APIs here this could clash with something, any future post with a form body would silently get the audience injected.

I've reduced the scope to GarminServiceUserRepository, the interceptor is now attached to a new client created from the globally injected one, and that client is  only used at one place. The global client is plain with no interceptors on it.
