### PR TITLE
Migrate Google Health subscriptions to manual mode (per-user routing)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,11 +66,6 @@ dependencies {
     implementation("org.slf4j:slf4j-api:${project.property("slf4jVersion")}")
 
     val jacksonVersion: String by project
-    // Force every Jackson module (including ones pulled transitively, e.g. by
-    // google-health-library) to the pinned version. radar-jersey 0.10.0 and
-    // RadarResourceEnhancer's KotlinModule() need 2.14.x; otherwise a transitive
-    // drags jackson-module-kotlin up to 2.20.x, whose KotlinModule constructor was
-    // removed -> NoSuchMethodError at startup.
     implementation(enforcedPlatform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,6 +66,12 @@ dependencies {
     implementation("org.slf4j:slf4j-api:${project.property("slf4jVersion")}")
 
     val jacksonVersion: String by project
+    // Force every Jackson module (including ones pulled transitively, e.g. by
+    // google-health-library) to the pinned version. radar-jersey 0.10.0 and
+    // RadarResourceEnhancer's KotlinModule() need 2.14.x; otherwise a transitive
+    // drags jackson-module-kotlin up to 2.20.x, whose KotlinModule constructor was
+    // removed -> NoSuchMethodError at startup.
+    implementation(enforcedPlatform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")

--- a/gateway.yml
+++ b/gateway.yml
@@ -39,24 +39,41 @@ pushIntegration:
                 # Key prefix for locks
                 lockPrefix: radar-push-garmin/lock/
     googlehealth:
-        enabled: false
+        enabled: true
+
+        # --- RADAR REST-source-auth (user repository) ---
+        userRepositoryClass: org.radarbase.push.integration.google.user.GoogleHealthServiceUserRepository
         userRepositoryUrl: http://rest-source-auth:8080/rest-sources/backend/
         userRepositoryClientId: radar_pushendpoint
         userRepositoryClientSecret: ""
         userRepositoryTokenUrl: http://rest-source-auth:8080/rest-sources/backend/token/
-        googleCloudProjectId:
-        subscriberId:
-        subscriberEndpointUri:
-        subscriberSecret: ""   # set to a 32+ byte random string; Google sends this back as Authorization
+
+        # --- Google Health API ---
+        apiBaseUrl: https://health.googleapis.com/v4
+        googleCloudProjectId: ""
+
+        # --- Subscriber ---
+        subscriberId: radar-pushendpoint-<deployment>-<study> # MUST be unique per deployment (and maybe study) (e.g. radar-pep-stage)
+        subscriberEndpointUri: https://push-endpoint:8090/push/integrations/googlehealth/notifications
+        subscriberSecret: ""   # 32+ byte random string; Google echoes it back as the Authorization header
+        serviceAccountKeyPath: ""      # REQUIRED — path to the Google service-account JSON. Empty/missing => subscriber registration AND reconcile do not run.
+
+        # --- Per-user subscription reconcile ---
+        subscriptionCreatePolicy: MANUAL                 # default; MANUAL is what we want. AUTOMATIC would require subscriptionReconcileEnabled: false
+        subscriptionReconcileEnabled: true
+        subscriptionReconcileIntervalMinutes: 5
+        subscriptionReconcileMaxDeletesPerPass: 50       # skip + alarm if one pass would delete more than this (0 disables the cap)
+
+        # Data types that drive PINGs (the subscriber config + each per-user subscription subscribe to these)
         triggerDataTypes:
             - steps
             - sleep
             - exercise
             - daily-resting-heart-rate
-            - total-calories
             - heart-rate
             - daily-sleep-temperature-derivations
 
+        # All data types fetched/produced (superset of triggerDataTypes; non-trigger ones are caught up via the offset cursor)
         enabledDataTypes:
             - steps
             - heart-rate
@@ -69,12 +86,13 @@ pushIntegration:
             - sleep
             - exercise
 
+        # --- Historical backfill ---
         backfill:
             enabled: true
             redis:
                 uri: redis://redis:6379
                 lockPrefix: radar-push-googlehealth/lock
             maxThreads: 4
-            maxBackfillPeriod: P730D
+            maxBackfillPeriod: P730D                      # ISO-8601 duration (2 years)
             chunkSizeDays: 7
             iterationIntervalMinutes: 10

--- a/gateway.yml
+++ b/gateway.yml
@@ -93,6 +93,5 @@ pushIntegration:
                 uri: redis://redis:6379
                 lockPrefix: radar-push-googlehealth/lock
             maxThreads: 4
-            maxBackfillPeriod: P730D                      # ISO-8601 duration (2 years)
             chunkSizeDays: 7
             iterationIntervalMinutes: 10

--- a/src/main/kotlin/org/radarbase/gateway/Config.kt
+++ b/src/main/kotlin/org/radarbase/gateway/Config.kt
@@ -138,6 +138,13 @@ data class GoogleHealthConfig(
     val subscriberEndpointUri: String = "",
     val subscriberSecret: String = "",
     val serviceAccountKeyPath: String = "",
+    val subscriptionReconcileEnabled: Boolean = true,
+    val subscriptionReconcileIntervalMinutes: Long = 5,
+    /**
+     * If a single deletion would delete more subscriptions than this, it skips
+     * deletion and alarms instead
+     */
+    val subscriptionReconcileMaxDeletesPerPass: Int = 50,
     val triggerDataTypes: List<String> = listOf(
         "steps",
         "sleep",

--- a/src/main/kotlin/org/radarbase/gateway/Config.kt
+++ b/src/main/kotlin/org/radarbase/gateway/Config.kt
@@ -7,6 +7,8 @@ import org.radarbase.gateway.inject.PushIntegrationEnhancerFactory
 import org.radarbase.jersey.enhancer.EnhancerFactory
 import org.radarbase.push.integration.garmin.user.GarminUserRepository
 import org.radarbase.googlehealth.user.GoogleHealthUserRepository
+import org.radarbase.jersey.config.ConfigLoader.copyEnv
+import org.radarbase.jersey.config.ConfigLoader.copyOnChange
 import java.net.URI
 import java.time.Duration
 import java.time.Instant
@@ -32,12 +34,24 @@ data class Config(
         kafka.validate()
         pushIntegration.validate()
     }
+
+    fun withEnv() = this.copyOnChange(pushIntegration, {
+        it.withEnv()
+    }, {
+        copy(pushIntegration = it)
+    })
 }
 
 data class PushIntegrationConfig(
     val garmin: GarminConfig = GarminConfig(),
     val googlehealth: GoogleHealthConfig = GoogleHealthConfig(),
 ) {
+    fun withEnv() = this.copyOnChange(googlehealth, {
+        it.withEnv()
+    }, {
+        copy(googlehealth = it)
+    })
+
     fun validate() {
         garmin.validate()
         googlehealth.validate()
@@ -49,8 +63,7 @@ data class GarminConfig(
     val consumerKey: String = "",
     val consumerSecret: String = "",
     val backfill: BackfillConfig = BackfillConfig(),
-    val userRepositoryClass: String =
-        "org.radarbase.push.integration.garmin.user.GarminServiceUserRepository",
+    val userRepositoryClass: String = "org.radarbase.push.integration.garmin.user.GarminServiceUserRepository",
     val userRepositoryUrl: String = "http://localhost:8080/",
     val userRepositoryClientId: String = "radar_pushendpoint",
     val userRepositoryClientSecret: String = "",
@@ -82,8 +95,7 @@ data class GarminConfig(
     fun validate() {
         if (enabled) {
             check(GarminUserRepository::class.java.isAssignableFrom(userRepository)) {
-                "$userRepositoryClass is not valid. Please specify a class that is a subclass of" +
-                    " `org.radarbase.push.integration.garmin.user.GarminUserRepository`"
+                "$userRepositoryClass is not valid. Please specify a class that is a subclass of" + " `org.radarbase.push.integration.garmin.user.GarminUserRepository`"
             }
         }
     }
@@ -114,20 +126,19 @@ data class BackfillConfig(
 )
 
 data class RedisConfig(
-    val uri: URI = URI("redis://localhost:6379"),
-    val lockPrefix: String = "radar-push-garmin/lock"
+    val uri: URI = URI("redis://localhost:6379"), val lockPrefix: String = "radar-push-garmin/lock"
 )
 
 data class UserBackfillConfig(
-    val userId: String,
-    val startDate: Instant,
-    val endDate: Instant
+    val userId: String, val startDate: Instant, val endDate: Instant
 )
+
+/** How Google creates per-user subscriptions for this deployment's subscriber. */
+enum class SubscriptionCreatePolicy { MANUAL, AUTOMATIC }
 
 data class GoogleHealthConfig(
     val enabled: Boolean = false,
-    val userRepositoryClass: String =
-        "org.radarbase.push.integration.google.user.GoogleHealthServiceUserRepository",
+    val userRepositoryClass: String = "org.radarbase.push.integration.google.user.GoogleHealthServiceUserRepository",
     val userRepositoryUrl: String = "http://localhost:8080/",
     val userRepositoryClientId: String = "radar_pushendpoint",
     val userRepositoryClientSecret: String = "",
@@ -137,7 +148,8 @@ data class GoogleHealthConfig(
     val subscriberId: String = "radar-pep",
     val subscriberEndpointUri: String = "",
     val subscriberSecret: String = "",
-    val serviceAccountKeyPath: String = "",
+    val serviceAccountKeyPath: String? = null,
+    val subscriptionCreatePolicy: SubscriptionCreatePolicy = SubscriptionCreatePolicy.MANUAL,
     val subscriptionReconcileEnabled: Boolean = true,
     val subscriptionReconcileIntervalMinutes: Long = 5,
     /**
@@ -146,13 +158,7 @@ data class GoogleHealthConfig(
      */
     val subscriptionReconcileMaxDeletesPerPass: Int = 50,
     val triggerDataTypes: List<String> = listOf(
-        "steps",
-        "sleep",
-        "exercise",
-        "daily-resting-heart-rate",
-        "total-calories",
-        "heart-rate",
-        "daily-sleep-temperature-derivations"
+        "steps", "sleep", "exercise", "daily-resting-heart-rate", "heart-rate", "daily-sleep-temperature-derivations"
     ),
     val enabledDataTypes: List<String> = listOf(
         "steps", "heart-rate", "heart-rate-variability", "oxygen-saturation",
@@ -174,6 +180,10 @@ data class GoogleHealthConfig(
 ) {
     val userRepository: Class<*> = Class.forName(userRepositoryClass)
 
+    fun withEnv() = this.copyEnv("GOOGLE_HEALTH_SERVICE_ACCOUNT_PATH") {
+        copy(serviceAccountKeyPath = it)
+    }
+
     fun validate() {
         if (enabled) {
             check(googleCloudProjectId.isNotEmpty()) {
@@ -185,9 +195,13 @@ data class GoogleHealthConfig(
             check(subscriberSecret.isNotEmpty()) {
                 "subscriberSecret must be set when google health is enabled"
             }
+            if (subscriptionCreatePolicy == SubscriptionCreatePolicy.AUTOMATIC) {
+                check(!subscriptionReconcileEnabled) {
+                    "subscriptionReconcileEnabled must be false with an AUTOMATIC subscriber — " + "automatic subscriptions can't be listed or deleted, so reconcile cannot manage them."
+                }
+            }
             check(GoogleHealthUserRepository::class.java.isAssignableFrom(userRepository)) {
-                "$userRepositoryClass is not valid. Please specify a class that is a subclass of" +
-                    " `org.radarbase.googlehealth.user.GoogleHealthUserRepository`"
+                "$userRepositoryClass is not valid. Please specify a class that is a subclass of" + " `org.radarbase.googlehealth.user.GoogleHealthUserRepository`"
             }
         }
     }
@@ -232,15 +246,13 @@ data class KafkaConfig(
     val serialization: Map<String, Any> = mapOf()
 ) {
     fun withDefaults(): KafkaConfig = copy(
-        producer = producerDefaults + producer,
-        admin = mutableMapOf<String, Any>().apply {
+        producer = producerDefaults + producer, admin = mutableMapOf<String, Any>().apply {
             producer[BOOTSTRAP_SERVERS_CONFIG]?.let {
                 this[BOOTSTRAP_SERVERS_CONFIG] = it
             }
             this += adminDefaults
             this += admin
-        },
-        serialization = serializationDefaults + serialization
+        }, serialization = serializationDefaults + serialization
     )
 
     fun validate() {
@@ -262,9 +274,7 @@ data class KafkaConfig(
             "delivery.timeout.ms" to 6000
         )
         private val adminDefaults = mapOf(
-            "default.api.timeout.ms" to 6000,
-            "request.timeout.ms" to 3000,
-            "retries" to 5
+            "default.api.timeout.ms" to 6000, "request.timeout.ms" to 3000, "retries" to 5
         )
 
         private val serializationDefaults = mapOf<String, Any>(

--- a/src/main/kotlin/org/radarbase/gateway/Config.kt
+++ b/src/main/kotlin/org/radarbase/gateway/Config.kt
@@ -214,10 +214,14 @@ data class GoogleHealthBackfillConfig(
         lockPrefix = "radar-push-googlehealth/lock",
     ),
     val maxThreads: Int = 4,
-    val maxBackfillPeriod: Duration = Duration.ofDays(365 * 2L),
+    val maxBackfillPeriod: Duration = Duration.ofDays(MAX_BACKFILL_DAYS),
     val chunkSizeDays: Long = 7,
     val iterationIntervalMinutes: Long = 10,
-)
+) {
+    companion object {
+        private const val MAX_BACKFILL_DAYS = 365 * 2L
+    }
+}
 
 data class GatewayServerConfig(
     /** Base URL to serve data with. This will determine the base path and the port. */

--- a/src/main/kotlin/org/radarbase/gateway/main.kt
+++ b/src/main/kotlin/org/radarbase/gateway/main.kt
@@ -22,6 +22,7 @@ fun main(args: Array<String>) {
                 .registerModule(JavaTimeModule())
         )
             .withDefaults()
+            .withEnv()
     } catch (ex: IllegalArgumentException) {
         logger.error("No configuration file was found.")
         logger.error("Usage: radar-gateway <config-file>")

--- a/src/main/kotlin/org/radarbase/push/integration/GoogleHealthPushIntegrationResourceEnhancer.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/GoogleHealthPushIntegrationResourceEnhancer.kt
@@ -29,7 +29,9 @@ import org.radarbase.push.integration.garmin.util.offset.OffsetRedisPersistence
 import org.radarbase.push.integration.google.auth.GoogleHealthAuthValidator
 import org.radarbase.push.integration.google.service.GoogleHealthApiService
 import org.radarbase.push.integration.google.service.GoogleHealthBackfillService
-import org.radarbase.push.integration.google.service.SubscriberRegistrationService
+import org.radarbase.push.integration.google.subscriptions.GoogleHealthSubscriptionReconcileService
+import org.radarbase.push.integration.google.subscriptions.GoogleHealthSubscriptionService
+import org.radarbase.push.integration.google.subscriber.SubscriberRegistrationService
 import org.radarbase.googlehealth.user.GoogleHealthUserRepository
 import org.radarbase.push.integration.google.util.GoogleServiceAccountTokenProvider
 import redis.clients.jedis.JedisPool
@@ -44,13 +46,16 @@ class GoogleHealthPushIntegrationResourceEnhancer(private val config: Config) :
     }
 
     override val classes: Array<Class<*>>
-        get() = if (config.pushIntegration.googlehealth.backfill.enabled) {
-            arrayOf(
-                SubscriberRegistrationService::class.java,
-                GoogleHealthBackfillService::class.java,
-            )
-        } else {
-            arrayOf(SubscriberRegistrationService::class.java)
+        get() {
+            val ghConfig = config.pushIntegration.googlehealth
+            val services = mutableListOf<Class<*>>(SubscriberRegistrationService::class.java)
+            if (ghConfig.backfill.enabled) {
+                services += GoogleHealthBackfillService::class.java
+            }
+            if (ghConfig.subscriptionReconcileEnabled) {
+                services += GoogleHealthSubscriptionReconcileService::class.java
+            }
+            return services.toTypedArray()
         }
 
     override fun AbstractBinder.enhance() {
@@ -78,6 +83,10 @@ class GoogleHealthPushIntegrationResourceEnhancer(private val config: Config) :
 
         bind(GoogleServiceAccountTokenProvider::class.java)
             .to(GoogleServiceAccountTokenProvider::class.java)
+            .`in`(Singleton::class.java)
+
+        bind(GoogleHealthSubscriptionService::class.java)
+            .to(GoogleHealthSubscriptionService::class.java)
             .`in`(Singleton::class.java)
     }
 }

--- a/src/main/kotlin/org/radarbase/push/integration/google/service/SubscriberRegistrationService.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/google/service/SubscriberRegistrationService.kt
@@ -190,7 +190,7 @@ class SubscriberRegistrationService(
     private fun buildSubscriberConfigs(): List<Map<String, Any>> = listOf(
         mapOf(
             "dataTypes" to ghConfig.triggerDataTypes,
-            "subscriptionCreatePolicy" to "AUTOMATIC",
+            "subscriptionCreatePolicy" to "MANUAL",
         )
     )
 
@@ -199,9 +199,10 @@ class SubscriberRegistrationService(
         desired: List<Map<String, Any>>,
     ): Boolean {
         if (existing == null || existing.size != desired.size) return false
-        val existingDataTypes = existing.firstOrNull()?.get("dataTypes")
-        val desiredDataTypes = desired.firstOrNull()?.get("dataTypes")
-        return existingDataTypes == desiredDataTypes
+        val existingConfig = existing.firstOrNull()
+        val desiredConfig = desired.firstOrNull()
+        return existingConfig?.get("dataTypes") == desiredConfig?.get("dataTypes") &&
+            existingConfig?.get("subscriptionCreatePolicy") == desiredConfig?.get("subscriptionCreatePolicy")
     }
 
     companion object {

--- a/src/main/kotlin/org/radarbase/push/integration/google/subscriber/SubscriberRegistrationService.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/google/subscriber/SubscriberRegistrationService.kt
@@ -1,3 +1,19 @@
+/**
+* Copyright 2026 King's College London
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 package org.radarbase.push.integration.google.subscriber
 
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -172,7 +188,7 @@ class SubscriberRegistrationService(
     private fun buildSubscriberConfigs(): List<Map<String, Any>> = listOf(
         mapOf(
             "dataTypes" to ghConfig.triggerDataTypes,
-            "subscriptionCreatePolicy" to "MANUAL",
+            "subscriptionCreatePolicy" to ghConfig.subscriptionCreatePolicy.name,
         )
     )
 

--- a/src/main/kotlin/org/radarbase/push/integration/google/subscriber/SubscriberRegistrationService.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/google/subscriber/SubscriberRegistrationService.kt
@@ -1,20 +1,4 @@
-/*
- * Copyright 2026 King's College London
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package org.radarbase.push.integration.google.service
+package org.radarbase.push.integration.google.subscriber
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.ws.rs.core.Context
@@ -23,14 +7,13 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.glassfish.jersey.server.monitoring.ApplicationEvent
-import org.glassfish.jersey.server.monitoring.ApplicationEvent.Type.DESTROY_FINISHED
-import org.glassfish.jersey.server.monitoring.ApplicationEvent.Type.INITIALIZATION_FINISHED
 import org.glassfish.jersey.server.monitoring.ApplicationEventListener
 import org.glassfish.jersey.server.monitoring.RequestEvent
 import org.glassfish.jersey.server.monitoring.RequestEventListener
 import org.radarbase.gateway.Config
 import org.radarbase.push.integration.google.util.GoogleServiceAccountTokenProvider
 import org.slf4j.LoggerFactory
+import kotlin.collections.get
 
 /**
  * Registers a Google Health webhook subscriber at application startup.
@@ -49,8 +32,8 @@ class SubscriberRegistrationService(
 
     override fun onEvent(event: ApplicationEvent?) {
         when (event?.type) {
-            INITIALIZATION_FINISHED -> registerSubscriber()
-            DESTROY_FINISHED -> {
+            ApplicationEvent.Type.INITIALIZATION_FINISHED -> registerSubscriber()
+            ApplicationEvent.Type.DESTROY_FINISHED -> {
                 // Intentionally not unsubscribing on shutdown. Keeping the subscription alive across
                 // restarts avoids a window where PINGs would be missed. If operators need to remove the subscriber.
                 logger.info("Application shutting down — subscriber {} left active", subscriberId)
@@ -151,9 +134,8 @@ class SubscriberRegistrationService(
             return
         }
 
-        logger.info("Subscriber {} exists but needs update — patching", subscriberId)
-        val url = "$baseUrl/projects/$projectId/subscribers/$subscriberId" +
-            "?updateMask=endpointUri,subscriberConfigs"
+        logger.info("Subscriber {} exists but needs update", subscriberId)
+        val url = "$baseUrl/projects/$projectId/subscribers/$subscriberId?updateMask=endpointUri,subscriberConfigs"
         val payload = mapOf(
             "endpointUri" to desiredUri,
             "subscriberConfigs" to desiredConfigs,
@@ -168,7 +150,7 @@ class SubscriberRegistrationService(
         httpClient.newCall(request).execute().use { response ->
             val respBody = response.body?.string()
             if (response.isSuccessful) {
-                logger.info("Subscriber {} patched successfully — state ACTIVE", subscriberId)
+                logger.info("Subscriber {} patched successfully", subscriberId)
             } else {
                 logger.error(
                     "Failed to patch subscriber {}: HTTP {} — {}",

--- a/src/main/kotlin/org/radarbase/push/integration/google/subscriber/SubscriberRegistrationService.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/google/subscriber/SubscriberRegistrationService.kt
@@ -29,6 +29,8 @@ import org.glassfish.jersey.server.monitoring.RequestEventListener
 import org.radarbase.gateway.Config
 import org.radarbase.push.integration.google.util.GoogleServiceAccountTokenProvider
 import org.slf4j.LoggerFactory
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlin.collections.get
 
 /**
@@ -45,13 +47,15 @@ class SubscriberRegistrationService(
     private val projectId = ghConfig.googleCloudProjectId
     private val subscriberId = ghConfig.subscriberId
     private val baseUrl = ghConfig.apiBaseUrl
+    private val scheduler = Executors.newSingleThreadScheduledExecutor()
 
     override fun onEvent(event: ApplicationEvent?) {
         when (event?.type) {
-            ApplicationEvent.Type.INITIALIZATION_FINISHED -> registerSubscriber()
+            ApplicationEvent.Type.INITIALIZATION_FINISHED -> scheduleRegistration()
             ApplicationEvent.Type.DESTROY_FINISHED -> {
+                scheduler.shutdownNow()
                 // Intentionally not unsubscribing on shutdown. Keeping the subscription alive across
-                // restarts avoids a window where PINGs would be missed. If operators need to remove the subscriber.
+                // restarts avoids a window where PINGs would be missed.
                 logger.info("Application shutting down — subscriber {} left active", subscriberId)
             }
             else -> { /* no-op */ }
@@ -60,7 +64,7 @@ class SubscriberRegistrationService(
 
     override fun onRequest(requestEvent: RequestEvent?): RequestEventListener? = null
 
-    private fun registerSubscriber() {
+    private fun scheduleRegistration() {
         if (!tokenProvider.isConfigured) {
             logger.warn(
                 "Service account not configured -- skipping subscriber registration. " +
@@ -68,20 +72,57 @@ class SubscriberRegistrationService(
             )
             return
         }
-        try {
-            val accessToken = tokenProvider.getAccessToken()
-            val existing = getSubscriber(accessToken)
-            if (existing == null) {
-                createSubscriber(accessToken)
-            } else {
-                maybeUpdateSubscriber(existing, accessToken)
+        logger.info(
+            "Scheduling subscriber {} registration in {}s (waiting for the HTTP server to accept requests).",
+            subscriberId, REGISTRATION_INITIAL_DELAY_SECONDS,
+        )
+        scheduler.schedule(::registerWithRetry, REGISTRATION_INITIAL_DELAY_SECONDS, TimeUnit.SECONDS)
+    }
+
+    /**
+     * Ensures the subscriber exists, retrying a few times. The first attempt can fail because Google's
+     * create-time verification handshake reaches us before the server is fully ready,
+     * so we retry with a fixed delay rather than give up after one shot.
+     */
+    private fun registerWithRetry() {
+        for (attempt in 1..MAX_REGISTRATION_ATTEMPTS) {
+            val ok = try {
+                ensureSubscriber()
+            } catch (ex: Exception) {
+                logger.warn(
+                    "Subscriber {} registration attempt {}/{} errored",
+                    subscriberId, attempt, MAX_REGISTRATION_ATTEMPTS, ex,
+                )
+                false
             }
-        } catch (e: Exception) {
-            logger.error(
-                "Failed to register subscriber {} — PINGs will not be received until " +
-                    "the issue is resolved and PEP is restarted: {}",
-                subscriberId, e.message, e,
-            )
+            if (ok) {
+                logger.info("Subscriber {} ensured (attempt {}/{})", subscriberId, attempt, MAX_REGISTRATION_ATTEMPTS)
+                return
+            }
+            if (attempt < MAX_REGISTRATION_ATTEMPTS) {
+                try {
+                    TimeUnit.SECONDS.sleep(REGISTRATION_RETRY_DELAY_SECONDS)
+                } catch (ex: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    return
+                }
+            }
+        }
+        logger.error(
+            "Subscriber {} could not be ensured after {} attempts. PINGs will not be received until the issue is" +
+                " resolved and the Push Endpoint is restarted.",
+            subscriberId, MAX_REGISTRATION_ATTEMPTS,
+        )
+    }
+
+    /** Creates or updates the subscriber. Returns true when it is in the desired state. */
+    private fun ensureSubscriber(): Boolean {
+        val accessToken = tokenProvider.getAccessToken()
+        val existing = getSubscriber(accessToken)
+        return if (existing == null) {
+            createSubscriber(accessToken)
+        } else {
+            maybeUpdateSubscriber(existing, accessToken)
         }
     }
 
@@ -109,7 +150,7 @@ class SubscriberRegistrationService(
         }
     }
 
-    private fun createSubscriber(accessToken: String) {
+    private fun createSubscriber(accessToken: String): Boolean {
         logger.info("Creating subscriber {} for project {}", subscriberId, projectId)
         val url = "$baseUrl/projects/$projectId/subscribers?subscriberId=$subscriberId"
         val payload = buildSubscriberPayload()
@@ -124,18 +165,19 @@ class SubscriberRegistrationService(
             val respBody = response.body?.string()
             if (response.isSuccessful) {
                 logger.info("Subscriber(ID: {}) created. Listening on {}", subscriberId, ghConfig.subscriberEndpointUri)
-            } else {
-                logger.error(
-                    "Failed to create subscriber {}: HTTP {} - {}. " +
-                        "If subscriberEndpointUri ({}) does not match the live deployment, " +
-                        "Google will reject the verification handshake.",
-                    subscriberId, response.code, respBody, ghConfig.subscriberEndpointUri,
-                )
+                return true
             }
+            logger.error(
+                "Failed to create subscriber {}: HTTP {} - {}. " +
+                    "If subscriberEndpointUri ({}) does not match the live deployment, " +
+                    "Google will reject the verification handshake.",
+                subscriberId, response.code, respBody, ghConfig.subscriberEndpointUri,
+            )
+            return false
         }
     }
 
-    private fun maybeUpdateSubscriber(existing: Map<*, *>, accessToken: String) {
+    private fun maybeUpdateSubscriber(existing: Map<*, *>, accessToken: String): Boolean {
         val existingUri = existing["endpointUri"] as? String
         val desiredUri = ghConfig.subscriberEndpointUri
 
@@ -147,7 +189,7 @@ class SubscriberRegistrationService(
 
         if (!needsUpdate) {
             logger.info("Subscriber {} already exists and is up-to-date — state ACTIVE", subscriberId)
-            return
+            return true
         }
 
         logger.info("Subscriber {} exists but needs update", subscriberId)
@@ -167,12 +209,13 @@ class SubscriberRegistrationService(
             val respBody = response.body?.string()
             if (response.isSuccessful) {
                 logger.info("Subscriber {} patched successfully", subscriberId)
-            } else {
-                logger.error(
-                    "Failed to patch subscriber {}: HTTP {} — {}",
-                    subscriberId, response.code, respBody,
-                )
+                return true
             }
+            logger.error(
+                "Failed to patch subscriber {}: HTTP {} — {}",
+                subscriberId, response.code, respBody,
+            )
+            return false
         }
     }
 
@@ -204,6 +247,9 @@ class SubscriberRegistrationService(
     }
 
     companion object {
+        private const val REGISTRATION_INITIAL_DELAY_SECONDS = 60L
+        private const val REGISTRATION_RETRY_DELAY_SECONDS = 30L
+        private const val MAX_REGISTRATION_ATTEMPTS = 3
         private val JSON_MEDIA_TYPE = "application/json".toMediaType()
         private val logger = LoggerFactory.getLogger(SubscriberRegistrationService::class.java)
     }

--- a/src/main/kotlin/org/radarbase/push/integration/google/subscriber/SubscriberRegistrationService.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/google/subscriber/SubscriberRegistrationService.kt
@@ -167,6 +167,10 @@ class SubscriberRegistrationService(
                 logger.info("Subscriber(ID: {}) created. Listening on {}", subscriberId, ghConfig.subscriberEndpointUri)
                 return true
             }
+            if (response.code == 409) {
+                logger.info("Subscriber {} already exists (HTTP 409) — treating as success", subscriberId)
+                return true
+            }
             logger.error(
                 "Failed to create subscriber {}: HTTP {} - {}. " +
                     "If subscriberEndpointUri ({}) does not match the live deployment, " +

--- a/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/GoogleHealthSubscriptionReconcileService.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/GoogleHealthSubscriptionReconcileService.kt
@@ -26,7 +26,6 @@ import org.glassfish.jersey.server.monitoring.RequestEvent
 import org.glassfish.jersey.server.monitoring.RequestEventListener
 import org.radarbase.gateway.Config
 import org.radarbase.googlehealth.user.GoogleHealthUserRepository
-import org.radarbase.googlehealth.user.User
 import org.radarbase.push.integration.common.auth.DelegatedAuthValidator.Companion.GOOGLE_HEALTH_QUALIFIER
 import org.radarbase.push.integration.garmin.util.RedisRemoteLockManager
 import org.radarbase.push.integration.google.subscriptions.model.RemoteSubscription
@@ -106,16 +105,6 @@ class GoogleHealthSubscriptionReconcileService(
             return
         }
 
-        val withdrawn = try {
-            userRepository.fetchUnauthorizedUsers()
-        } catch (ex: IOException) {
-            logger.warn("Rest source backend unavailable when fetching unauthorized users ", ex)
-            return
-        } catch (ex: NoSuchElementException) {
-            logger.warn("Withdrawn fetchUnauthorizedUsers returned 404", ex)
-            return
-        }
-
         val authorizedIds = authorized.mapTo(mutableSetOf()) { it.serviceUserId }
         val remote = try {
             subscriptionService.listSubscriptions()
@@ -147,21 +136,19 @@ class GoogleHealthSubscriptionReconcileService(
             }
         }
 
-        deleteStale(authorizedIds, withdrawn, remote)
+        deleteStale(authorizedIds, remote)
     }
 
     /**
-     * Deletes subscriptions for users no longer authorized — those explicitly withdrawn and those
-     * removed entirely.
+     * Deletes subscriptions whose user is not in the current authorized set. A withdrawn user is
+     * removed from Rest Sources entirely (not returned as unauthorized), so they fall out of the
+     * authorized set and their leftover subscription is cleaned up here.
      */
     private fun deleteStale(
         authorizedIds: Set<String>,
-        unauthorized: List<User>,
         remote: List<RemoteSubscription>,
     ): Pair<Int, Int> {
-        val unauthorizedIds = unauthorized.mapTo(mutableSetOf()) { it.serviceUserId }
-        val knownIds = HashSet(authorizedIds).apply { addAll(unauthorizedIds) }
-        val staleSubscriptions = remote.filter { it.healthUserId != null && it.healthUserId !in knownIds }
+        val staleSubscriptions = remote.filter { it.healthUserId != null && it.healthUserId !in authorizedIds }
 
         if (maxDeletesPerPass > 0 && staleSubscriptions.size > maxDeletesPerPass) {
             logger.warn(

--- a/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/GoogleHealthSubscriptionReconcileService.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/GoogleHealthSubscriptionReconcileService.kt
@@ -139,7 +139,7 @@ class GoogleHealthSubscriptionReconcileService(
         val desiredDataTypes = ghConfig.triggerDataTypes.toSet()
         remote.forEach { sub ->
             val userId = sub.healthUserId ?: return@forEach
-            if (userId in authorizedIds && sub.dataTypes.toSet() != desiredDataTypes) {
+            if (userId in authorizedIds && sub.dataTypeIds.toSet() != desiredDataTypes) {
                 when (val result = subscriptionService.patchSubscription(sub.name, ghConfig.triggerDataTypes)) {
                     is SubscriptionResult.Success -> logger.info("Patched dataTypes for user={}", userId)
                     else -> logger.warn("Reconcile patch failed for user={}: {}", userId, result)

--- a/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/GoogleHealthSubscriptionReconcileService.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/GoogleHealthSubscriptionReconcileService.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 King's College London
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.radarbase.push.integration.google.subscriptions
+
+import jakarta.inject.Named
+import jakarta.ws.rs.core.Context
+import org.glassfish.jersey.server.monitoring.ApplicationEvent
+import org.glassfish.jersey.server.monitoring.ApplicationEvent.Type.DESTROY_FINISHED
+import org.glassfish.jersey.server.monitoring.ApplicationEvent.Type.INITIALIZATION_FINISHED
+import org.glassfish.jersey.server.monitoring.ApplicationEventListener
+import org.glassfish.jersey.server.monitoring.RequestEvent
+import org.glassfish.jersey.server.monitoring.RequestEventListener
+import org.radarbase.gateway.Config
+import org.radarbase.googlehealth.user.GoogleHealthUserRepository
+import org.radarbase.googlehealth.user.User
+import org.radarbase.push.integration.common.auth.DelegatedAuthValidator.Companion.GOOGLE_HEALTH_QUALIFIER
+import org.radarbase.push.integration.garmin.util.RedisRemoteLockManager
+import org.radarbase.push.integration.google.subscriptions.model.RemoteSubscription
+import org.radarbase.push.integration.google.subscriptions.model.SubscriptionResult
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.collections.mapNotNullTo
+
+class GoogleHealthSubscriptionReconcileService(
+    @param:Named(GOOGLE_HEALTH_QUALIFIER) private val userRepository: GoogleHealthUserRepository,
+    @param:Context private val subscriptionService: GoogleHealthSubscriptionService,
+    @param:Context private val locks: RedisRemoteLockManager,
+    @Context config: Config,
+) : ApplicationEventListener {
+
+    private val ghConfig = config.pushIntegration.googlehealth
+    private val enabled = ghConfig.subscriptionReconcileEnabled
+    private val intervalMinutes = ghConfig.subscriptionReconcileIntervalMinutes
+    private val maxDeletesPerPass = ghConfig.subscriptionReconcileMaxDeletesPerPass
+    private val scheduler = Executors.newSingleThreadScheduledExecutor()
+
+    override fun onEvent(event: ApplicationEvent?) {
+        when (event?.type) {
+            INITIALIZATION_FINISHED -> start()
+            DESTROY_FINISHED -> stop()
+            else -> { /* no-op */
+            }
+        }
+    }
+
+    override fun onRequest(requestEvent: RequestEvent?): RequestEventListener? = null
+
+    private fun start() {
+        if (!enabled) {
+            logger.info("Google Health subscription reconcile disabled by config. Skipping scheduler start.")
+            return
+        }
+        if (!subscriptionService.isConfigured) {
+            logger.warn("Service account not configured — subscription reconcile will not run.")
+            return
+        }
+        logger.info("Starting Google Health subscription reconcile (intervalMinutes={}).", intervalMinutes)
+        scheduler.scheduleAtFixedRate(::tick, 1, intervalMinutes, TimeUnit.MINUTES)
+    }
+
+    private fun stop() {
+        logger.info("Stopping Google Health subscription reconcile...")
+        scheduler.shutdown()
+        try {
+            scheduler.awaitTermination(30, TimeUnit.SECONDS)
+        } catch (ex: InterruptedException) {
+            logger.warn("Interrupted while stopping subscription reconcile", ex)
+            Thread.currentThread().interrupt()
+        }
+    }
+
+    private fun tick() {
+        try {
+            locks.tryRunLocked(RECONCILE_LOCK) { reconcile() }
+        } catch (ex: Throwable) {
+            logger.warn("Google Health subscription reconcile iteration failed", ex)
+        }
+    }
+
+    private fun reconcile() {
+        val authorized = try {
+            userRepository.stream().toList()
+        } catch (ex: IOException) {
+            logger.warn("Reconcile skipped: could not fetch authorized users from Rest Sources", ex)
+            return
+        }
+
+        val withdrawn = try {
+            userRepository.fetchUnauthorizedUsers()
+        } catch (ex: IOException) {
+            logger.warn("Rest source backend unavailable when fetching unauthorized users ", ex)
+            return
+        } catch (ex: NoSuchElementException) {
+            logger.warn("Withdrawn fetchUnauthorizedUsers returned 404", ex)
+            return
+        }
+
+        val authorizedIds = authorized.mapTo(mutableSetOf()) { it.serviceUserId }
+        val remote = try {
+            subscriptionService.listSubscriptions()
+        } catch (ex: Exception) {
+            logger.warn("Reconcile skipped: could not list Google subscriptions", ex)
+            return
+        }
+
+        val remoteIds = remote.mapNotNullTo(mutableSetOf()) { it.healthUserId }
+
+        // Create subscriptions for authorized users that Google does not yet have.
+        authorized.forEach { user ->
+            if (user.serviceUserId !in remoteIds) {
+                when (val result = subscriptionService.createSubscription(user.serviceUserId)) {
+                    is SubscriptionResult.Success -> logger.info("Created subscription for user={}", user.serviceUserId)
+                    else -> logger.warn("Reconcile create failed for user={}: {}", user.serviceUserId, result)
+                }
+            }
+        }
+        deleteStale(authorizedIds, withdrawn, remote)
+    }
+
+    /**
+     * Deletes subscriptions for users no longer authorized — those explicitly withdrawn and those
+     * removed entirely.
+     */
+    private fun deleteStale(
+        authorizedIds: Set<String>,
+        unauthorized: List<User>,
+        remote: List<RemoteSubscription>,
+    ): Pair<Int, Int> {
+        val unauthorizedIds = unauthorized.mapTo(mutableSetOf()) { it.serviceUserId }
+        val knownIds = HashSet(authorizedIds).apply { addAll(unauthorizedIds) }
+        val staleSubscriptions = remote.filter { it.healthUserId != null && it.healthUserId !in knownIds }
+
+        if (maxDeletesPerPass > 0 && staleSubscriptions.size > maxDeletesPerPass) {
+            logger.warn(
+                "Reconcile would delete {} subscription(s), over the safety cap ({}). Skipping " +
+                    "deletion this pass — investigate before mass-removal.",
+                staleSubscriptions.size, maxDeletesPerPass,
+            )
+            return 0 to 0
+        }
+
+        var deleted = 0
+        var deleteFailed = 0
+        staleSubscriptions.forEach { sub ->
+            when (val result = subscriptionService.deleteByName(sub.name)) {
+                is SubscriptionResult.Success -> {
+                    deleted++
+                    logger.info("Reconcile deleted orphaned subscription user={} reason=deregistered", sub.healthUserId)
+                }
+
+                else -> {
+                    deleteFailed++
+                    logger.warn("Reconcile delete failed user={}: {}", sub.healthUserId, result)
+                }
+            }
+        }
+        return deleted to deleteFailed
+    }
+
+    companion object {
+        private const val RECONCILE_LOCK = "googlehealth-subscription-reconcile"
+        private val logger = LoggerFactory.getLogger(GoogleHealthSubscriptionReconcileService::class.java)
+    }
+}

--- a/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/GoogleHealthSubscriptionReconcileService.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/GoogleHealthSubscriptionReconcileService.kt
@@ -130,6 +130,18 @@ class GoogleHealthSubscriptionReconcileService(
                 }
             }
         }
+
+        val desiredDataTypes = ghConfig.triggerDataTypes.toSet()
+        remote.forEach { sub ->
+            val userId = sub.healthUserId ?: return@forEach
+            if (userId in authorizedIds && sub.dataTypes.toSet() != desiredDataTypes) {
+                when (val result = subscriptionService.patchSubscription(sub.name, ghConfig.triggerDataTypes)) {
+                    is SubscriptionResult.Success -> logger.info("Patched dataTypes for user={}", userId)
+                    else -> logger.warn("Reconcile patch failed for user={}: {}", userId, result)
+                }
+            }
+        }
+
         deleteStale(authorizedIds, withdrawn, remote)
     }
 

--- a/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/GoogleHealthSubscriptionReconcileService.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/GoogleHealthSubscriptionReconcileService.kt
@@ -70,8 +70,13 @@ class GoogleHealthSubscriptionReconcileService(
             logger.warn("Service account not configured — subscription reconcile will not run.")
             return
         }
-        logger.info("Starting Google Health subscription reconcile (intervalMinutes={}).", intervalMinutes)
-        scheduler.scheduleAtFixedRate(::tick, 1, intervalMinutes, TimeUnit.MINUTES)
+        logger.info(
+            "Starting Google Health subscription reconcile (firstRunDelay={}s, intervalMinutes={}).",
+            RECONCILE_INITIAL_DELAY_SECONDS, intervalMinutes,
+        )
+        scheduler.scheduleAtFixedRate(
+            ::tick, RECONCILE_INITIAL_DELAY_SECONDS, intervalMinutes * 60, TimeUnit.SECONDS,
+        )
     }
 
     private fun stop() {
@@ -187,6 +192,7 @@ class GoogleHealthSubscriptionReconcileService(
 
     companion object {
         private const val RECONCILE_LOCK = "googlehealth-subscription-reconcile"
+        private const val RECONCILE_INITIAL_DELAY_SECONDS = 90L
         private val logger = LoggerFactory.getLogger(GoogleHealthSubscriptionReconcileService::class.java)
     }
 }

--- a/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/GoogleHealthSubscriptionService.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/GoogleHealthSubscriptionService.kt
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2026 King's College London
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.radarbase.push.integration.google.subscriptions
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.ws.rs.core.Context
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.radarbase.gateway.Config
+import org.radarbase.push.integration.google.subscriptions.model.RemoteSubscription
+import org.radarbase.push.integration.google.subscriptions.model.SubscriptionResult
+import org.radarbase.push.integration.google.util.GoogleServiceAccountTokenProvider
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import java.security.MessageDigest
+
+/**
+ * Manages per-user Google Health subscriptions for this deployment's subscriber
+ */
+class GoogleHealthSubscriptionService(
+    @param:Context private val config: Config,
+    @param:Context private val httpClient: OkHttpClient,
+    @param:Context private val objectMapper: ObjectMapper,
+    @param:Context private val tokenProvider: GoogleServiceAccountTokenProvider,
+) {
+    private val ghConfig = config.pushIntegration.googlehealth
+    private val projectId = ghConfig.googleCloudProjectId
+    private val subscriberId = ghConfig.subscriberId
+    private val baseUrl = ghConfig.apiBaseUrl.trimEnd('/')
+    private val defaultDataTypes = ghConfig.triggerDataTypes
+
+    val isConfigured: Boolean
+        get() = tokenProvider.isConfigured
+
+    fun createSubscription(
+        healthUserId: String,
+        dataTypes: List<String> = defaultDataTypes,
+    ): SubscriptionResult {
+        if (!tokenProvider.isConfigured) return SubscriptionResult.NotConfigured
+        val subscriptionId = subscriptionIdFor(healthUserId)
+        val url = "$baseUrl/projects/$projectId/subscribers/$subscriberId/subscriptions?subscriptionId=$subscriptionId"
+        val payload = mapOf(
+            "user" to userResourceName(healthUserId),
+            "dataTypes" to dataTypes,
+        )
+        val body = objectMapper.writeValueAsString(payload).toRequestBody(JSON_MEDIA_TYPE)
+        return execute(healthUserId, "create") { token ->
+            Request.Builder()
+                .url(url)
+                .post(body)
+                .header("Authorization", "Bearer $token")
+                .header("Content-Type", "application/json")
+                .build()
+        }
+    }
+
+    fun deleteSubscription(healthUserId: String): SubscriptionResult {
+        if (!tokenProvider.isConfigured) return SubscriptionResult.NotConfigured
+        val subscriptionId = subscriptionIdFor(healthUserId)
+        val url = "$baseUrl/projects/$projectId/subscribers/$subscriberId/subscriptions/$subscriptionId"
+        return execute(healthUserId, "delete") { token ->
+            Request.Builder()
+                .url(url)
+                .delete()
+                .header("Authorization", "Bearer $token")
+                .build()
+        }
+    }
+
+    /**
+     * Deletes a subscription by its full Google resource name (as returned by [listSubscriptions]).
+     * Reconciliation uses this so it removes exactly what Google reported, independent of how the
+     * subscription's id was generated (e.g. a leftover AUTOMATIC or out-of-band subscription).
+     * Idempotent: a missing subscription reports [SubscriptionResult.Success].
+     */
+    fun deleteByName(name: String): SubscriptionResult {
+        if (!tokenProvider.isConfigured) return SubscriptionResult.NotConfigured
+        val url = "$baseUrl/$name"
+        return execute(name, "delete") { token ->
+            Request.Builder()
+                .url(url)
+                .delete()
+                .header("Authorization", "Bearer $token")
+                .build()
+        }
+    }
+
+    /**
+     * Lists all subscriptions currently registered under this deployment's subscriber, following
+     * pagination. This is the source of truth for reconciliation.
+     *
+     * Throws on any non-success response so a transient failure is never mistaken for "Google has
+     * no subscriptions" — which a reconcile loop would otherwise read as "delete everything".
+     */
+    @Throws(IOException::class)
+    fun listSubscriptions(): List<RemoteSubscription> {
+        check(tokenProvider.isConfigured) { "Service account not configured" }
+        val token = tokenProvider.getAccessToken()
+        val result = mutableListOf<RemoteSubscription>()
+        var pageToken: String? = null
+        do {
+            val builder = "$baseUrl/projects/$projectId/subscribers/$subscriberId/subscriptions"
+                .toHttpUrl().newBuilder()
+                .addQueryParameter("pageSize", PAGE_SIZE.toString())
+            if (!pageToken.isNullOrEmpty()) builder.addQueryParameter("pageToken", pageToken)
+            val request = Request.Builder()
+                .url(builder.build())
+                .get()
+                .header("Authorization", "Bearer $token")
+                .header("Accept", "application/json")
+                .build()
+            httpClient.newCall(request).execute().use { response ->
+                val respBody = response.body?.string()
+                if (!response.isSuccessful) {
+                    throw IOException(
+                        "List subscriptions failed for subscriber $subscriberId: HTTP ${response.code} - $respBody",
+                    )
+                }
+                val tree = if (respBody.isNullOrEmpty()) {
+                    objectMapper.createObjectNode()
+                } else {
+                    objectMapper.readTree(respBody)
+                }
+                tree["subscriptions"]?.forEach { node -> result += parseSubscription(node) }
+                pageToken = tree["nextPageToken"]?.asText()?.takeIf { it.isNotEmpty() }
+            }
+        } while (pageToken != null)
+        return result
+    }
+
+    private fun execute(
+        identifier: String,
+        action: String,
+        buildRequest: (String) -> Request,
+    ): SubscriptionResult {
+        val token = try {
+            tokenProvider.getAccessToken()
+        } catch (ex: Exception) {
+            logger.warn("Could not obtain service-account token for {} of {}", action, identifier, ex)
+            return SubscriptionResult.TransientFailure("token: ${ex.message}")
+        }
+        return try {
+            httpClient.newCall(buildRequest(token)).execute().use { response ->
+                val respBody = response.body?.string()
+                when {
+                    response.isSuccessful -> {
+                        val name = respBody?.let {
+                            runCatching {
+                                objectMapper.readTree(it)["name"]?.asText()
+                            }.getOrNull()
+                        }
+                        logger.info("Subscription {} ok for {} (name={})", action, identifier, name)
+                        SubscriptionResult.Success(name)
+                    }
+                    // create: subscription already present. delete: subscription already gone.
+                    response.code == 409 || response.code == 404 -> SubscriptionResult.Success(null)
+
+                    response.code == 429 || response.code in 500..599 -> {
+                        logger.warn(
+                            "Transient {} failure for {}: HTTP {} - {}",
+                            action,
+                            identifier,
+                            response.code,
+                            respBody
+                        )
+                        SubscriptionResult.TransientFailure("HTTP ${response.code}")
+                    }
+
+                    else -> {
+                        logger.error(
+                            "Permanent {} failure for {}: HTTP {} - {}",
+                            action,
+                            identifier,
+                            response.code,
+                            respBody
+                        )
+                        SubscriptionResult.PermanentFailure(response.code, respBody)
+                    }
+                }
+            }
+        } catch (ex: IOException) {
+            logger.warn("I/O error during subscription {} for {}", action, identifier, ex)
+            SubscriptionResult.TransientFailure("io: ${ex.message}")
+        }
+    }
+
+    private fun parseSubscription(node: JsonNode): RemoteSubscription = RemoteSubscription(
+        name = node["name"]?.asText() ?: "",
+        user = node["user"]?.asText() ?: "",
+        dataTypes = node["dataTypes"]?.mapNotNull { it.asText() } ?: emptyList(),
+    )
+
+    private fun userResourceName(healthUserId: String): String = "users/$healthUserId"
+
+    /**
+     * Subscription id derived from the health user id. We hash rather than use the raw id because the health user id's
+     * character set and length are not guaranteed to satisfy Google's resource-id rules.
+     */
+    private fun subscriptionIdFor(healthUserId: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(healthUserId.toByteArray())
+        val hex = digest.joinToString("") { "%02x".format(it) }
+        return "u" + hex.take(SUBSCRIPTION_ID_HEX_LEN)
+    }
+
+    companion object {
+        private val JSON_MEDIA_TYPE = "application/json".toMediaType()
+        private const val PAGE_SIZE = 1000
+        private const val SUBSCRIPTION_ID_HEX_LEN = 32
+        private val logger = LoggerFactory.getLogger(GoogleHealthSubscriptionService::class.java)
+    }
+}

--- a/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/GoogleHealthSubscriptionService.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/GoogleHealthSubscriptionService.kt
@@ -54,7 +54,6 @@ class GoogleHealthSubscriptionService(
         healthUserId: String,
         dataTypes: List<String> = defaultDataTypes,
     ): SubscriptionResult {
-        if (!tokenProvider.isConfigured) return SubscriptionResult.NotConfigured
         val subscriptionId = subscriptionIdFor(healthUserId)
         val url = "$baseUrl/projects/$projectId/subscribers/$subscriberId/subscriptions?subscriptionId=$subscriptionId"
         val payload = mapOf(
@@ -73,7 +72,6 @@ class GoogleHealthSubscriptionService(
     }
 
     fun deleteSubscription(healthUserId: String): SubscriptionResult {
-        if (!tokenProvider.isConfigured) return SubscriptionResult.NotConfigured
         val subscriptionId = subscriptionIdFor(healthUserId)
         val url = "$baseUrl/projects/$projectId/subscribers/$subscriberId/subscriptions/$subscriptionId"
         return execute(healthUserId, "delete") { token ->
@@ -92,7 +90,6 @@ class GoogleHealthSubscriptionService(
      * Idempotent: a missing subscription reports [SubscriptionResult.Success].
      */
     fun deleteByName(name: String): SubscriptionResult {
-        if (!tokenProvider.isConfigured) return SubscriptionResult.NotConfigured
         val url = "$baseUrl/$name"
         return execute(name, "delete") { token ->
             Request.Builder()
@@ -103,12 +100,25 @@ class GoogleHealthSubscriptionService(
         }
     }
 
+    fun patchSubscription(name: String, dataTypes: List<String>): SubscriptionResult {
+        val url = "$baseUrl/$name?updateMask=dataTypes"
+        val body = objectMapper.writeValueAsString(mapOf("dataTypes" to dataTypes))
+            .toRequestBody(JSON_MEDIA_TYPE)
+        return execute(name, "patch") { token ->
+            Request.Builder()
+                .url(url)
+                .patch(body)
+                .header("Authorization", "Bearer $token")
+                .header("Content-Type", "application/json")
+                .build()
+        }
+    }
+
     /**
-     * Lists all subscriptions currently registered under this deployment's subscriber, following
-     * pagination. This is the source of truth for reconciliation.
+     * Returns every subscription under this deployment's subscriber (following all pages).
      *
-     * Throws on any non-success response so a transient failure is never mistaken for "Google has
-     * no subscriptions" — which a reconcile loop would otherwise read as "delete everything".
+     * Throws on any error instead of returning an empty list, so reconcile treats a failed read as
+     * "unknown" and skips the pass — a hiccup is never mistaken for "Google has no subscriptions".
      */
     @Throws(IOException::class)
     fun listSubscriptions(): List<RemoteSubscription> {
@@ -151,6 +161,7 @@ class GoogleHealthSubscriptionService(
         action: String,
         buildRequest: (String) -> Request,
     ): SubscriptionResult {
+        if (!tokenProvider.isConfigured) return SubscriptionResult.NotConfigured
         val token = try {
             tokenProvider.getAccessToken()
         } catch (ex: Exception) {

--- a/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/model/RemoteSubscription.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/model/RemoteSubscription.kt
@@ -24,4 +24,13 @@ data class RemoteSubscription(
 ) {
     val healthUserId: String?
         get() = user.removePrefix("users/").takeIf { it.isNotEmpty() && it != user }
+
+    /**
+     * Bare data-type tokens (e.g. "steps"), with Google's "users/{id}/dataTypes/" qualifier stripped.
+     * Google stores and returns subscription data types as fully-qualified resource names like
+     * (users/{userId}/dataTypes/daily-resting-heart-rate), while the
+     * config and create payloads use bare tokens, normalise before comparing the two.
+     */
+    val dataTypeIds: List<String>
+        get() = dataTypes.map { it.substringAfterLast('/') }
 }

--- a/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/model/RemoteSubscription.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/model/RemoteSubscription.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 King's College London
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.radarbase.push.integration.google.subscriptions.model
+
+/** A subscription as returned by Google's list endpoint. */
+data class RemoteSubscription(
+    val name: String,
+    val user: String,
+    val dataTypes: List<String>,
+) {
+    val healthUserId: String?
+        get() = user.removePrefix("users/").takeIf { it.isNotEmpty() && it != user }
+}

--- a/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/model/SubscriptionResult.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/google/subscriptions/model/SubscriptionResult.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 King's College London
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.radarbase.push.integration.google.subscriptions.model
+
+sealed interface SubscriptionResult {
+    /** The subscription is in the desired state (created, already existed, or already deleted). */
+    data class Success(val name: String?) : SubscriptionResult
+
+    /** No service account configured, the call was not attempted. */
+    object NotConfigured : SubscriptionResult
+
+    /** Retryable failure (network, 429, 5xx). The caller should retry later. */
+    data class TransientFailure(val message: String) : SubscriptionResult
+
+    /** Non-retryable failure (e.g. 4xx other than 404/409). The caller should not blindly retry. */
+    data class PermanentFailure(val code: Int, val body: String?) : SubscriptionResult
+}

--- a/src/main/kotlin/org/radarbase/push/integration/google/user/GoogleHealthServiceUserRepository.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/google/user/GoogleHealthServiceUserRepository.kt
@@ -144,15 +144,6 @@ class GoogleHealthServiceUserRepository(
         nextFetch = Instant.now().plus(FETCH_THRESHOLD)
     }
 
-    /**
-     * Fetch users who have de-authorized / withdrawn (`authorized=false`).
-     */
-    @Throws(IOException::class)
-    override fun fetchUnauthorizedUsers(): List<User> {
-        val request = requestFor("users?source-type=$GOOGLEHEALTH_SOURCE&authorized=false").build()
-        return makeRequest<GoogleHealthUsers>(request, userListReader).users
-    }
-
     @Throws(IOException::class)
     private fun requestFor(relativeUrl: String): Request.Builder {
         val url: HttpUrl = baseUrl.resolve(relativeUrl)

--- a/src/main/kotlin/org/radarbase/push/integration/google/user/GoogleHealthServiceUserRepository.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/google/user/GoogleHealthServiceUserRepository.kt
@@ -125,8 +125,7 @@ class GoogleHealthServiceUserRepository(
     }
 
     override fun deregisterUser(serviceUserId: String) {
-        val request =
-            requestFor("source-clients/$GOOGLEHEALTH_SOURCE/authorization/$serviceUserId")
+        val request = requestFor("source-clients/$GOOGLEHEALTH_SOURCE/authorization/$serviceUserId")
                 .method("DELETE", EMPTY_BODY).build()
         return makeRequest(request, null)
     }
@@ -143,6 +142,15 @@ class GoogleHealthServiceUserRepository(
         timedCachedUsers = makeRequest<GoogleHealthUsers>(request, userListReader).users
 
         nextFetch = Instant.now().plus(FETCH_THRESHOLD)
+    }
+
+    /**
+     * Fetch users who have de-authorized / withdrawn (`authorized=false`).
+     */
+    @Throws(IOException::class)
+    override fun fetchUnauthorizedUsers(): List<User> {
+        val request = requestFor("users?source-type=$GOOGLEHEALTH_SOURCE&authorized=false").build()
+        return makeRequest<GoogleHealthUsers>(request, userListReader).users
     }
 
     @Throws(IOException::class)

--- a/src/main/kotlin/org/radarbase/push/integration/google/util/GoogleServiceAccountTokenProvider.kt
+++ b/src/main/kotlin/org/radarbase/push/integration/google/util/GoogleServiceAccountTokenProvider.kt
@@ -32,7 +32,7 @@ class GoogleServiceAccountTokenProvider(
 ) {
     private val credentials: GoogleCredentials? = run {
         val keyPath = config.pushIntegration.googlehealth.serviceAccountKeyPath
-        if (keyPath.isEmpty()) {
+        if (keyPath.isNullOrEmpty()) {
             logger.warn(
                 "No serviceAccountKeyPath configured, subscriber registration will not work"
             )


### PR DESCRIPTION
Moves Google Health from automatic to manual subscriptions so each user can be routed to the right deployment under one (or multiple) client id(s). The app registers its subscriber with the `MANUAL` policy and a loop keeps per-user subscriptions in sync with the authorized users from Rest Source Auth.
